### PR TITLE
[Feature] - Create Flavor

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -67,6 +67,26 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+
+    flavorDimensions += "default"
+
+    productFlavors {
+        create("development") {
+            dimension = "default"
+            resValue "string", "app_name", "IseBa Development"
+            applicationIdSuffix = ".development"
+        }
+        create("staging") {
+            dimension = "default"
+            resValue "string", "app_name", "IseBa Staging"
+            applicationIdSuffix = ".staging"
+        }
+        create("production") {
+            dimension = "default"
+            resValue "string", "app_name", "IseBa"
+        }
+}
+
 }
 
 flutter {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application
-        android:label="ISeBa"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/launcher_icon">
         <activity


### PR DESCRIPTION
## Pull Request: Add Android Flavors Support

### Summary

This PR introduces support for Android build flavors to allow separate builds for different environments:

- `development`
- `staging`
- `production`

### Changes Made

- Added flavor definitions in `build.gradle` (`development`, `staging`, `production`)
- Configured `applicationIdSuffix` for `development` and `staging`
- Updated `AndroidManifest.xml` to use a unique app name per flavor via `resValue`